### PR TITLE
Fixed Flaky Test

### DIFF
--- a/src/test/java/com/authy/api/UserStatusTest.java
+++ b/src/test/java/com/authy/api/UserStatusTest.java
@@ -1,5 +1,6 @@
 package com.authy.api;
 
+import org.custommonkey.xmlunit.XMLAssert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,11 +48,20 @@ public class UserStatusTest {
         assertEquals(String.format("[%s, %s]", DEVICE_A, DEVICE_B), userStatusMap.get("devices"));
     }
 
+    public void assertXMLEqualsNonStrict(String xml1, String xml2) {
+        try {
+            XMLAssert.assertXMLEqual(xml1, xml2);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Test
     public void testToXML() {
         String userStatusXml = userStatus.toXML();
         assertNotNull(userStatusXml);
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+        assertXMLEqualsNonStrict("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
                         "<user_status><status>200</status><userId>1234</userId><success>true</success><confirmed>true</confirmed>" +
                         "<registered>true</registered><country_code>1</country_code>" +
                         "<devices><device>deviceA</device><device>deviceB</device></devices>" +


### PR DESCRIPTION
This pull request fixes the flaky test caused due to non-determinism. The function testToXML() originally compares two XML strings using assertEquals(). In my solution, I have implemented the assertXMLEqual() of XMLAssert which resolves the flakiness by comparing the XML strings not too strictly. The XMLAssert class is part of the xmlunit library. Thus, this PR makes the XML strings deterministic and resolves the flaky test.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license